### PR TITLE
Honour the configured volume type in create_test_server

### DIFF
--- a/tempest/common/compute.py
+++ b/tempest/common/compute.py
@@ -253,6 +253,8 @@ def create_test_server(clients, validatable=False, validation_resources=None,
         if CONF.compute.compute_volume_common_az:
             params.setdefault('availability_zone',
                               CONF.compute.compute_volume_common_az)
+        if CONF.volume.volume_type:
+            params.setdefault('volume_type', CONF.volume.volume_type)
         volume = volumes_client.create_volume(**params)
         try:
             waiters.wait_for_volume_resource_status(volumes_client,


### PR DESCRIPTION
The common.compute.create_test_server would not set the configured volume, so we end up with a volume-type which does not match the hypervisor.