### PR TITLE
Update base.py to fix Imagemembers test

### DIFF
--- a/tempest/api/image/base.py
+++ b/tempest/api/image/base.py
@@ -178,7 +178,7 @@ class BaseV2MemberImageTest(BaseV2ImageTest):
 
     def _list_image_ids_as_alt(self):
         image_list = self.alt_img_client.list_images()['images']
-        image_ids = map(lambda x: x['id'], image_list)
+        return [image['id'] for image in image_list]
         return image_ids
 
     def _create_image(self):


### PR DESCRIPTION
The root cause of this error is likely that self._list_image_ids_as_alt() is returning a map object, not a directly iterable list, so the assertNotIn() is comparing against the map object itself, which leads to unintended behavior.